### PR TITLE
Remove emphasis from asset ability dots

### DIFF
--- a/src/Asset/asset.css
+++ b/src/Asset/asset.css
@@ -96,6 +96,7 @@
 .dot {
   margin: -0.06em 0.27em 0 -0.03em;
   font-size: 1.58em;
+  font-style: normal;
 }
 
 .filled::before {


### PR DESCRIPTION
The asset ability dots appear to be *emphasized* in the editor (see image). Adding `font-style: normal` fixed it in the console.
![CleanShot 2021-05-05 at 17 48 55](https://user-images.githubusercontent.com/78855/117226939-9af9e700-adca-11eb-93ea-154660b028a3.png)
